### PR TITLE
kwargs integration in LLM calls for forward engines

### DIFF
--- a/evaluation/code_optimization/prompts.py
+++ b/evaluation/code_optimization/prompts.py
@@ -27,7 +27,8 @@ class CodeTestTimewithTests(Module):
     def __init__(self,
                  engine: EngineLM,
                  evaluation_instruction: str = default_instruction_test,
-                 system_prompt: Variable = None):
+                 system_prompt: Variable = None,
+                 **kwargs):
         super().__init__()
         if system_prompt:
             self.tt_system_prompt = system_prompt
@@ -44,7 +45,8 @@ class CodeTestTimewithTests(Module):
         self.formatted_llm_call = FormattedLLMCall(engine=self.engine,
                                                    format_string=self.format_string,
                                                    fields=self.fields,
-                                                   system_prompt=self.tt_system_prompt)
+                                                   system_prompt=self.tt_system_prompt,
+                                                   kwargs=kwargs)
 
     def forward(self, problem: str, program: Variable, tests: str) -> Variable:
         problem_variable = Variable(problem,

--- a/textgrad/autograd/llm_ops.py
+++ b/textgrad/autograd/llm_ops.py
@@ -19,7 +19,7 @@ from .function import Function, BackwardContext
 
 
 class LLMCall(Function):
-    def __init__(self, engine: EngineLM, system_prompt: Variable = None):
+    def __init__(self, engine: EngineLM, system_prompt: Variable = None, kwargs: dict = None):
         """The simple LLM call function. This function will call the LLM with the input and return the response, also register the grad_fn for backpropagation.
 
         :param engine: engine to use for the LLM call
@@ -32,6 +32,7 @@ class LLMCall(Function):
         self.system_prompt = system_prompt
         if self.system_prompt and self.system_prompt.get_role_description() is None:
             self.system_prompt.set_role_description(SYSTEM_PROMPT_DEFAULT_ROLE)
+        self.kwargs = kwargs
     
     def forward(self, input_variable: Variable, response_role_description: str = VARIABLE_OUTPUT_DEFAULT_ROLE) -> Variable:
         """
@@ -57,7 +58,7 @@ class LLMCall(Function):
         system_prompt_value = self.system_prompt.value if self.system_prompt else None
 
         # Make the LLM Call
-        response_text = self.engine(input_variable.value, system_prompt=system_prompt_value)
+        response_text = self.engine(input_variable.value, system_prompt=system_prompt_value, **self.kwargs)
 
         # Create the response variable
         response = Variable(
@@ -230,7 +231,8 @@ class FormattedLLMCall(LLMCall):
                  engine: EngineLM, 
                  format_string: str,
                  fields: dict[str, str],
-                 system_prompt: Variable = None):
+                 system_prompt: Variable = None,
+                 kwargs: dict = None):
         """This class is responsible for handling the formatting of the input before calling the LLM.
         It inherits from the LLMCall class and reuses its backward function.
 
@@ -243,7 +245,7 @@ class FormattedLLMCall(LLMCall):
         :param system_prompt: The system prompt to use for the LLM call. Default value depends on the engine.
         :type system_prompt: Variable, optional
         """
-        super().__init__(engine, system_prompt)
+        super().__init__(engine, system_prompt, kwargs)
         self.format_string = format_string
         self.fields = fields
     
@@ -273,7 +275,7 @@ class FormattedLLMCall(LLMCall):
         system_prompt_value = self.system_prompt.value if self.system_prompt else None
 
         # Make the LLM Call
-        response_text = self.engine(formatted_input_string, system_prompt=system_prompt_value)
+        response_text = self.engine(formatted_input_string, system_prompt=system_prompt_value, **self.kwargs)
 
         # Create the response variable
         response = Variable(
@@ -319,7 +321,7 @@ class LLMCall_with_in_context_examples(LLMCall):
         system_prompt_value = self.system_prompt.value if self.system_prompt else None
 
         # Make the LLM Call
-        response_text = self.engine(input_variable.value, system_prompt=system_prompt_value)
+        response_text = self.engine(input_variable.value, system_prompt=system_prompt_value, **self.kwargs)
 
 
         # Create the response variable

--- a/textgrad/autograd/multimodal_ops.py
+++ b/textgrad/autograd/multimodal_ops.py
@@ -29,7 +29,8 @@ class MultimodalLLMCall(Function):
     """
     def __init__(self, 
                  engine: Union[str, EngineLM], 
-                 system_prompt: Variable = None):
+                 system_prompt: Variable = None,
+                 kwargs: dict = None):
         super().__init__()
         self.engine = validate_engine_or_get_default(engine)
         validate_multimodal_engine(self.engine)
@@ -37,7 +38,7 @@ class MultimodalLLMCall(Function):
         self.system_prompt = system_prompt
         if self.system_prompt and self.system_prompt.get_role_description() is None:
             self.system_prompt.set_role_description(SYSTEM_PROMPT_DEFAULT_ROLE)
-    
+        self.kwargs = kwargs
     
     def forward(self, 
                 inputs: List[Variable], 
@@ -66,7 +67,7 @@ class MultimodalLLMCall(Function):
         system_prompt_value = self.system_prompt.value if self.system_prompt else None
         input_content = [inp.value for inp in inputs]
         # Make the LLM Call
-        response_text = self.engine(input_content, system_prompt=system_prompt_value)
+        response_text = self.engine(input_content, system_prompt=system_prompt_value, **self.kwargs)
 
         # Create the response variable
         response = Variable(
@@ -198,7 +199,8 @@ class OrderedFieldsMultimodalLLMCall(MultimodalLLMCall):
     def __init__(self, 
                  engine: Union[str, EngineLM], 
                  fields: List[str],
-                 system_prompt: Variable = None):
+                 system_prompt: Variable = None,
+                 kwargs: dict = None):
 
         self.engine = validate_engine_or_get_default(engine)
         validate_multimodal_engine(self.engine)
@@ -208,6 +210,7 @@ class OrderedFieldsMultimodalLLMCall(MultimodalLLMCall):
             self.system_prompt.set_role_description(SYSTEM_PROMPT_DEFAULT_ROLE)
 
         self.fields = fields
+        self.kwargs = kwargs
         
     def forward(self, 
                 inputs: dict[str, Variable], 
@@ -228,7 +231,7 @@ class OrderedFieldsMultimodalLLMCall(MultimodalLLMCall):
         system_prompt_value = self.system_prompt.value if self.system_prompt else None
 
         # Make the LLM Call
-        response_text = self.engine(forward_content, system_prompt=system_prompt_value)
+        response_text = self.engine(forward_content, system_prompt=system_prompt_value, **self.kwargs)
 
         # Create the response variable
         response = Variable(

--- a/textgrad/engine/together.py
+++ b/textgrad/engine/together.py
@@ -38,7 +38,7 @@ class ChatTogether(EngineLM, CachedEngine):
         self.model_string = model_string
 
     def generate(
-        self, prompt, system_prompt=None, temperature=0, max_tokens=2000, top_p=0.99
+        self, prompt, system_prompt=None, temperature=0, max_tokens=2000, top_p=0.99, **kwargs
     ):
 
         sys_prompt_arg = system_prompt if system_prompt else self.system_prompt
@@ -59,6 +59,7 @@ class ChatTogether(EngineLM, CachedEngine):
             temperature=temperature,
             max_tokens=max_tokens,
             top_p=top_p,
+            **kwargs
         )
 
         response = response.choices[0].message.content

--- a/textgrad/model.py
+++ b/textgrad/model.py
@@ -6,7 +6,7 @@ from textgrad.engine import EngineLM, get_engine
 from .config import SingletonBackwardEngine
 
 class BlackboxLLM(Module):
-    def __init__(self, engine: Union[EngineLM, str] = None, system_prompt: Union[Variable, str] = None):
+    def __init__(self, engine: Union[EngineLM, str] = None, system_prompt: Union[Variable, str] = None, **kwargs):
         """
         Initialize the LLM module.
 
@@ -25,7 +25,7 @@ class BlackboxLLM(Module):
         if isinstance(system_prompt, str):
             system_prompt = Variable(system_prompt, requires_grad=False, role_description="system prompt for the language model")
         self.system_prompt = system_prompt
-        self.llm_call = LLMCall(self.engine, self.system_prompt)
+        self.llm_call = LLMCall(self.engine, self.system_prompt, kwargs)
 
     def parameters(self):
         """

--- a/textgrad/optimizer/optimizer.py
+++ b/textgrad/optimizer/optimizer.py
@@ -87,7 +87,8 @@ class TextualGradientDescent(Optimizer):
                  new_variable_tags: List[str]=None,
                  optimizer_system_prompt: str=OPTIMIZER_SYSTEM_PROMPT,
                  in_context_examples: List[str]=None,
-                 gradient_memory: int=0):
+                 gradient_memory: int=0, 
+                 **kwargs):
         """TextualGradientDescent optimizer
 
         :param engine: the engine to use for updating variables
@@ -121,6 +122,7 @@ class TextualGradientDescent(Optimizer):
         self.gradient_memory = gradient_memory
         self.gradient_memory_dict = defaultdict(list)
         self.do_gradient_memory = (gradient_memory > 0)
+        self.kwargs = kwargs
 
     @property
     def constraint_text(self):
@@ -175,7 +177,7 @@ class TextualGradientDescent(Optimizer):
         """
         for parameter in self.parameters:
             prompt_update_parameter = self._update_prompt(parameter)
-            new_text = self.engine(prompt_update_parameter, system_prompt=self.optimizer_system_prompt)
+            new_text = self.engine(prompt_update_parameter, system_prompt=self.optimizer_system_prompt, **self.kwargs)
             logger.info(f"TextualGradientDescent optimizer response", extra={"optimizer.response": new_text})
             try:
                 new_value = new_text.split(self.new_variable_tags[0])[1].split(self.new_variable_tags[1])[0].strip()
@@ -201,7 +203,8 @@ class TextualGradientDescentwithMomentum(Optimizer):
                  constraints: List[str]=None,
                  new_variable_tags: List[str]=None,
                  in_context_examples: List[str]=None,
-                 optimizer_system_prompt: str=OPTIMIZER_SYSTEM_PROMPT):
+                 optimizer_system_prompt: str=OPTIMIZER_SYSTEM_PROMPT,
+                 **kwargs):
         super().__init__(parameters)
 
         if new_variable_tags is None:
@@ -222,6 +225,7 @@ class TextualGradientDescentwithMomentum(Optimizer):
         self.new_variable_tags = new_variable_tags
         self.in_context_examples = in_context_examples if in_context_examples is not None else []
         self.do_in_context_examples = (len(self.in_context_examples) > 0)
+        self.kwargs = kwargs
 
         logger.info(f"TextualGradientDescent initialized with momentum window: {momentum_window}")
 
@@ -267,7 +271,7 @@ class TextualGradientDescentwithMomentum(Optimizer):
         for idx, parameter in enumerate(self.parameters):
             self._update_momentum_storage(parameter, momentum_storage_idx=idx)
             prompt_update_parameter = self._update_prompt(parameter, momentum_storage_idx=idx)
-            new_text = self.engine(prompt_update_parameter, system_prompt=self.optimizer_system_prompt)
+            new_text = self.engine(prompt_update_parameter, system_prompt=self.optimizer_system_prompt, **self.kwargs)
             logger.info(f"TextualGradientDescentwithMomentum optimizer response", extra={"optimizer.response": new_text})
             try:
                 new_value = new_text.split(self.new_variable_tags[0])[1].split(self.new_variable_tags[1])[0].strip()


### PR DESCRIPTION
integrate calling kwargs in all llm calls and engines in textgrad. This does not cover backward engines. 